### PR TITLE
Update cache protocol environment variable

### DIFF
--- a/cache-client-examples/appcache-example/src/main/java/com/oracle/cloud/caching/example/UserService.java
+++ b/cache-client-examples/appcache-example/src/main/java/com/oracle/cloud/caching/example/UserService.java
@@ -11,7 +11,7 @@ import com.oracle.cloud.cache.basic.options.Transport;
 public class UserService extends AbstractUserService {
 	
 	private static final String CACHE_HOST = System.getenv("CACHING_INTERNAL_CACHE_URL");
-	private static final Optional<String> CACHE_PROTOCOL = Optional.ofNullable(System.getenv("CACHING_PROTOCOL"));
+	private static final Optional<String> CACHE_PROTOCOL = Optional.ofNullable(System.getenv("CACHE_PROTOCOL"));
 
 	public UserService() {
 		super();


### PR DESCRIPTION
As per https://github.com/oracle/accs-caching-java-sdk/blob/73b9d99c0906598ddd5d81f85d0a97a098df9088/cache-client-examples/appcache-example/deployment.json#L11, this should be CACHE_PROTOCOL